### PR TITLE
initial policy refactor

### DIFF
--- a/rl/algos/async_td3.py
+++ b/rl/algos/async_td3.py
@@ -1,6 +1,6 @@
 from rl.utils import ReplayBuffer_remote
 from rl.utils import AdaptiveParamNoiseSpec, distance_metric, perturb_actor_parameters
-from rl.policies.actor import Scaled_FF_Actor as O_Actor
+from rl.policies.actor import FF_Actor as O_Actor
 from rl.policies.critic import Dual_Q_Critic as Critic
 
 # Plot results
@@ -170,7 +170,7 @@ class Actor():
         # Initialize param noise (or set to none)
         self.noise_scale = noise_scale
         self.param_noise = AdaptiveParamNoiseSpec(initial_stddev=0.05, desired_action_stddev=self.noise_scale, adaptation_coefficient=1.05) if param_noise else None
-        self.policy_perturbed = O_Actor(self.state_dim, self.action_dim, self.max_action, hidden_size=hidden_size, env_name=env_name).to(self.device)
+        self.policy_perturbed = O_Actor(self.state_dim, self.action_dim, env_name=env_name, max_action=self.max_action).to(self.device)
 
         # Termination condition: max episode length
         self.max_traj_len = 400
@@ -363,13 +363,13 @@ class Learner():
         self.max_traj_len = 400
 
         # models and optimizers
-        self.actor = O_Actor(self.state_dim, self.action_dim, self.max_action, hidden_size=hidden_size, env_name=env_name).to(self.device)
-        self.actor_target = O_Actor(self.state_dim, self.action_dim, self.max_action, hidden_size=hidden_size, env_name=env_name).to(self.device)
+        self.actor = O_Actor(self.state_dim, self.action_dim, env_name=env_name, max_action=self.max_action).to(self.device)
+        self.actor_target = O_Actor(self.state_dim, self.action_dim, env_name=env_name, max_action=self.max_action).to(self.device)
         self.actor_target.load_state_dict(self.actor.state_dict())
         self.actor_optimizer = torch.optim.Adam(self.actor.parameters(), lr=a_lr)
 
-        self.critic = Critic(self.state_dim, self.action_dim, hidden_size=hidden_size, env_name=env_name).to(self.device)
-        self.critic_target = Critic(self.state_dim, self.action_dim, hidden_size=hidden_size, env_name=env_name).to(self.device)
+        self.critic = Critic(self.state_dim, self.action_dim, env_name=env_name).to(self.device)
+        self.critic_target = Critic(self.state_dim, self.action_dim, env_name=env_name).to(self.device)
         self.critic_target.load_state_dict(self.critic.state_dict())
         self.critic_optimizer = torch.optim.Adam(self.critic.parameters(), lr=c_lr)
 

--- a/rl/algos/dpg.py
+++ b/rl/algos/dpg.py
@@ -198,7 +198,7 @@ def run_experiment(args):
   from time import time
 
   from apex import env_factory, create_logger
-  from rl.policies.critic import FF_Critic, LSTM_Critic
+  from rl.policies.critic import FF_Q, LSTM_Q
   from rl.policies.actor import FF_Actor, LSTM_Actor
 
   import locale, os
@@ -218,11 +218,11 @@ def run_experiment(args):
   act_space = env.action_space.shape[0]
 
   if args.recurrent:
-    actor = LSTM_Actor(obs_space, act_space, hidden_size=args.hidden_size, env_name=args.env_name, hidden_layers=args.layers)
-    critic = LSTM_Critic(obs_space, act_space, hidden_size=args.hidden_size, env_name=args.env_name, hidden_layers=args.layers)
+    actor = LSTM_Actor(obs_space, act_space, env_name=args.env_name)
+    critic = LSTM_Q(obs_space, act_space, env_name=args.env_name)
   else:
-    actor = FF_Actor(obs_space, act_space, hidden_size=args.hidden_size, env_name=args.env_name, hidden_layers=args.layers)
-    critic = FF_Critic(obs_space, act_space, hidden_size=args.hidden_size, env_name=args.env_name, hidden_layers=args.layers)
+    actor = FF_Actor(obs_space, act_space, env_name=args.env_name)
+    critic = FF_Q(obs_space, act_space, env_name=args.env_name)
 
   algo = DPG(actor, critic, args.a_lr, args.c_lr, discount=args.discount, tau=args.tau, center_reward=args.center_reward, normalize=args.normalize)
 

--- a/rl/algos/mirror_ppo.py
+++ b/rl/algos/mirror_ppo.py
@@ -7,7 +7,7 @@ from torch.distributions import kl_divergence
 
 import numpy as np
 from rl.algos import PPO
-from rl.policies.actor import GaussianMLP_Actor
+from rl.policies import GaussianMLP_Actor
 from rl.policies.critic import GaussianMLP_Critic
 from rl.envs.normalize import get_normalization_params, PreNormalizer
 

--- a/rl/algos/mirror_ppo.py
+++ b/rl/algos/mirror_ppo.py
@@ -276,10 +276,7 @@ def run_experiment(args):
         critic = GaussianMLP_Critic(
             obs_dim, 
             env_name=args.env_name,
-            nonlinearity=torch.nn.functional.relu, 
-            bounded=True, 
-            init_std=np.exp(-2), 
-            learn_std=False,
+            nonlinearity=torch.nn.functional.relu,
             normc_init=False
         )
 

--- a/rl/algos/sync_td3.py
+++ b/rl/algos/sync_td3.py
@@ -6,7 +6,7 @@ from torch.autograd import Variable
 import torch.nn.functional as F
 
 from rl.utils.remote_replay import ReplayBuffer
-from rl.policies.actor import Scaled_FF_Actor as O_Actor
+from rl.policies.actor import FF_Actor as O_Actor
 from rl.policies.critic import Dual_Q_Critic as Critic
 
 import functools
@@ -97,14 +97,14 @@ def collect_experience(env_fn, policy, min_steps, max_traj_len, act_noise):
 
 class TD3():
     def __init__(self, state_dim, action_dim, max_action, a_lr, c_lr, env_name='NOT_SET'):
-        self.actor = O_Actor(state_dim, action_dim, max_action, env_name=env_name).to(device)
-        self.actor_target = O_Actor(state_dim, action_dim, max_action, env_name=env_name).to(device)
-        self.actor_perturbed = O_Actor(state_dim, action_dim, max_action, env_name=env_name).to(device)
+        self.actor = O_Actor(state_dim, action_dim, env_name=env_name, max_action=max_action).to(device)
+        self.actor_target = O_Actor(state_dim, action_dim, env_name=env_name, max_action=max_action).to(device)
+        self.actor_perturbed = O_Actor(state_dim, action_dim, env_name=env_name, max_action=max_action).to(device)
         self.actor_target.load_state_dict(self.actor.state_dict())
         self.actor_optimizer = torch.optim.Adam(self.actor.parameters(), lr=a_lr)
 
-        self.critic = Critic(state_dim, action_dim, hidden_size=256, env_name=env_name).to(device)
-        self.critic_target = Critic(state_dim, action_dim, hidden_size=256, env_name=env_name).to(device)
+        self.critic = Critic(state_dim, action_dim, env_name=env_name).to(device)
+        self.critic_target = Critic(state_dim, action_dim, env_name=env_name).to(device)
         self.critic_target.load_state_dict(self.critic.state_dict())
         self.critic_optimizer = torch.optim.Adam(self.critic.parameters(), lr=c_lr)
 

--- a/rl/policies/__init__.py
+++ b/rl/policies/__init__.py
@@ -1,4 +1,6 @@
 from .td3_actor_critic import *
+from .actor import Gaussian_FF_Actor as GaussianMLP_Actor # for legacy code
+from .actor import Gaussian_FF_Actor
 
 #from .linear import LinearMLP
 #from .recurrent import RecurrentNet

--- a/rl/policies/actor.py
+++ b/rl/policies/actor.py
@@ -77,7 +77,7 @@ class Gaussian_FF_Actor(Actor): # more consistent with other actor naming conven
   def init_parameters(self):
     if self.normc_init:
         self.apply(normc_fn)
-        self.network_out.weight.data.mul_(0.01)
+        self.means.weight.data.mul_(0.01)
 
   def _get_dist_params(self, state):
     if self.training == False:
@@ -86,7 +86,7 @@ class Gaussian_FF_Actor(Actor): # more consistent with other actor naming conven
     x = state
     for l in self.actor_layers:
         x = self.nonlinearity(l(x))
-    x = self.network_out(x)
+    x = self.means(x)
 
     if self.bounded:
         mean = torch.tanh(x) 

--- a/rl/policies/actor.py
+++ b/rl/policies/actor.py
@@ -40,15 +40,16 @@ class Linear_Actor(Actor):
     return self.action
 
 # Actor network for gaussian mlp
-class GaussianMLP_Actor(Actor):
-  def __init__(self, state_dim, action_dim, hidden_size=256, hidden_layers=2, env_name='NOT SET', nonlinearity=torch.tanh, init_std=1, learn_std=True, bounded=False, normc_init=True, obs_std=None, obs_mean=None):
-    super(GaussianMLP_Actor, self).__init__()
+#class GaussianMLP_Actor(Actor):
+class Gaussian_FF_Actor(Actor): # more consistent with other actor naming conventions
+  def __init__(self, state_dim, action_dim, layers=(256, 256), env_name='NOT SET', nonlinearity=torch.tanh, init_std=1, learn_std=True, bounded=False, normc_init=True, obs_std=None, obs_mean=None):
+    super(Gaussian_FF_Actor, self).__init__()
 
     self.actor_layers = nn.ModuleList()
-    self.actor_layers += [nn.Linear(state_dim, hidden_size)]
-    for _ in range(hidden_layers-1):
-        self.actor_layers += [nn.Linear(hidden_size, hidden_size)]
-    self.network_out = nn.Linear(hidden_size, action_dim)
+    self.actor_layers += [nn.Linear(state_dim, layers[0])]
+    for i in range(len(layers)-1):
+        self.actor_layers += [nn.Linear(layers[i], layers[i+1])]
+    self.means = nn.Linear(layers[-1], action_dim)
 
     if learn_std == True: # probably don't want to use this for ppo, always use fixed std
       self.log_stds = nn.Linear(layers[-1], action_dim)
@@ -76,8 +77,6 @@ class GaussianMLP_Actor(Actor):
   def init_parameters(self):
     if self.normc_init:
         self.apply(normc_fn)
-
-        #if self.dist.__class__.__name__ == "DiagGaussian":
         self.network_out.weight.data.mul_(0.01)
 
   def _get_dist_params(self, state):
@@ -102,22 +101,6 @@ class GaussianMLP_Actor(Actor):
     return mean, sd
 
   def forward(self, inputs):
-    """
-    if self.training == False:
-        inputs = (inputs - self.obs_mean) / self.obs_std
-
-    x = inputs
-    for l in self.actor_layers:
-        x = self.nonlinearity(l(x))
-    x = self.network_out(x)
-
-    if self.bounded:
-        mean = torch.tanh(x) 
-    else:
-        mean = x
-
-    self.action = mean
-    """
     mean, _ = self._get_dist_params(inputs)
     self.action = mean
 
@@ -127,8 +110,6 @@ class GaussianMLP_Actor(Actor):
     return self.action
 
   def act(self, inputs, deterministic=True): # make true by default for evaluation purposes
-    #action = self.dist.sample(self(inputs), deterministic=deterministic)
-
     mu, sd = self._get_dist_params(inputs)
     if not deterministic:
       self.action = torch.distributions.Normal(mu, sd).sample()
@@ -140,17 +121,16 @@ class GaussianMLP_Actor(Actor):
   def evaluate(self, inputs):
     mu, sd = self._get_dist_params(inputs)
     return torch.distributions.Normal(mu, sd)
-    #return self.dist.evaluate(x)
 
 class FF_Actor(Actor):
-  def __init__(self, state_dim, action_dim, hidden_size=256, hidden_layers=2, env_name='NOT SET', nonlinearity=F.relu, max_action=1):
+  def __init__(self, state_dim, action_dim, layers=(256, 256), env_name='NOT SET', nonlinearity=F.relu, max_action=1):
     super(FF_Actor, self).__init__()
 
     self.actor_layers = nn.ModuleList()
-    self.actor_layers += [nn.Linear(state_dim, hidden_size)]
-    for _ in range(hidden_layers-1):
-        self.actor_layers += [nn.Linear(hidden_size, hidden_size)]
-    self.network_out = nn.Linear(hidden_size, action_dim)
+    self.actor_layers += [nn.Linear(state_dim, layers[0])]
+    for i in range(len(layers)-1):
+        self.actor_layers += [nn.Linear(layers[i], layers[i+1])]
+    self.network_out = nn.Linear(layers[-1], action_dim)
 
     self.action = None
     self.action_dim = action_dim
@@ -172,47 +152,15 @@ class FF_Actor(Actor):
   def get_action(self):
     return self.action
 
-# identical to FF_Actor but allows output to scale to max_action
-class Scaled_FF_Actor(Actor):
-  def __init__(self, state_dim, action_dim, max_action, hidden_size=256, hidden_layers=2, env_name='NOT SET', nonlinearity=F.relu):
-    super(Scaled_FF_Actor, self).__init__()
-
-    self.max_action = max_action
-
-    self.actor_layers = nn.ModuleList()
-    self.actor_layers += [nn.Linear(state_dim, hidden_size)]
-    for _ in range(hidden_layers-1):
-        self.actor_layers += [nn.Linear(hidden_size, hidden_size)]
-    self.network_out = nn.Linear(hidden_size, action_dim)
-
-    self.action = None
-    self.action_dim = action_dim
-    self.env_name = env_name
-    self.nonlinearity = nonlinearity
-
-  def forward(self, state):
-    x = state
-    #print(x.size())
-    for idx, layer in enumerate(self.actor_layers):
-      x = self.nonlinearity(layer(x))
-
-    self.action = self.max_action * torch.tanh(self.network_out(x))
-    #print(self.action)
-    #exit(1)
-    return self.action
-
-  def get_action(self):
-    return self.action
-
 class LSTM_Actor(Actor):
-  def __init__(self, input_dim, action_dim, hidden_size=64, hidden_layers=1, env_name='NOT SET', nonlinearity=torch.tanh, max_action=1):
+  def __init__(self, input_dim, action_dim, layers=(128, 128), env_name='NOT SET', nonlinearity=torch.tanh, max_action=1):
     super(LSTM_Actor, self).__init__()
 
     self.actor_layers = nn.ModuleList()
-    self.actor_layers += [nn.LSTMCell(input_dim, hidden_size)]
-    for _ in range(hidden_layers-1):
-        self.actor_layers += [nn.LSTMCell(hidden_size, hidden_size)]
-    self.network_out = nn.Linear(hidden_size, action_dim)
+    self.actor_layers += [nn.LSTMCell(state_dim, layers[0])]
+    for i in range(len(layers)-1):
+        self.actor_layers += [nn.LSTMCell(layers[i], layers[i+1])]
+    self.network_out = nn.Linear(layers[i-1], action_dim)
 
     self.action = None
     self.action_dim = action_dim
@@ -239,8 +187,9 @@ class LSTM_Actor(Actor):
     self.cells  = [torch.zeros(batch_size, l.hidden_size) for l in self.actor_layers]
 
   def forward(self, x):
+    dims = len(x.size())
 
-    if len(x.size()) == 3: # if we get a batch of trajectories
+    if dims == 3: # if we get a batch of trajectories
       self.init_hidden_state(batch_size=x.size(1))
       action = []
       for t, x_t in enumerate(x):
@@ -249,43 +198,119 @@ class LSTM_Actor(Actor):
           c, h = self.cells[idx], self.hidden[idx]
           self.hidden[idx], self.cells[idx] = layer(x_t, (h, c))
           x_t = self.hidden[idx]
-        x_t = self.network_out(x_t)
+        x_t = self.nonlinearity(self.network_out(x_t))
         action.append(x_t)
 
       x = torch.stack([a.float() for a in action])
+      self.action = x
 
-    elif len(x.size()) == 2: # if we get a whole trajectory
-      self.init_hidden_state()
-
-      self.action = []
-      for t, x_t in enumerate(x):
-        x_t = x_t.view(1, -1)
-
-        for idx, layer in enumerate(self.actor_layers):
-          h, c = self.hidden[idx], self.cells[idx]
-          self.hidden[idx], self.cells[idx] = layer(x_t, (h, c))
-          x_t = self.hidden[idx]
-        x_t = self.nonlinearity(self.network_out(x_t))
-        self.action.append(x_t)
-
-      x = torch.cat([a.float() for a in self.action])
-
-    elif len(x.size()) == 1: # if we get a single timestep
-      x = x.view(1, -1)
+    else:
+      if dims == 1: # if we get a single timestep (if not, assume we got a batch of single timesteps)
+        x = x.view(1, -1)
 
       for idx, layer in enumerate(self.actor_layers):
         h, c = self.hidden[idx], self.cells[idx]
         self.hidden[idx], self.cells[idx] = layer(x, (h, c))
         x = self.hidden[idx]
-      x = self.nonlinearity(self.network_out(x))[0]
+      x = self.nonlinearity(self.network_out(x))
 
-    else:
-      print("Invalid input dimensions.")
-      exit(1)
+      if dims == 1:
+        x = x.view(-1)
+      self.action = x
 
-    self.action = x * self.max_action
     return x
   
+  def get_action(self):
+    return self.action
+
+class Gaussian_LSTM_Actor(Actor):
+  def __init__(self, state_dim, action_dim, layers=(128, 128), env_name=None, nonlinearity=F.tanh, normc_init=False, max_action=1, fixed_std=None):
+    super(Gaussian_LSTM_Actor, self).__init__()
+
+    self.actor_layers = nn.ModuleList()
+    self.actor_layers += [nn.LSTMCell(state_dim, layers[0])]
+    for i in range(len(layers)-1):
+        self.actor_layers += [nn.LSTMCell(layers[i], layers[i+1])]
+    self.network_out = nn.Linear(layers[i-1], action_dim)
+
+    self.action = None
+    self.action_dim = action_dim
+    self.init_hidden_state()
+    self.env_name = env_name
+    self.nonlinearity = nonlinearity
+    self.max_action = max_action
+    
+    self.is_recurrent = True
+
+    if fixed_std is None:
+      self.log_stds = nn.Linear(layers[-1], action_dim)
+      self.learn_std = True
+    else:
+      self.fixed_std = fixed_std
+      self.learn_std = False
+
+    if normc_init:
+      self.initialize_parameters()
+
+  def _get_dist_params(self, state):
+    dims = len(state.size())
+
+    x = state
+    if dims == 3: # if we get a batch of trajectories
+      self.init_hidden_state(batch_size=x.size(1))
+      action = []
+      for t, x_t in enumerate(x):
+
+        for idx, layer in enumerate(self.actor_layers):
+          c, h = self.cells[idx], self.hidden[idx]
+          self.hidden[idx], self.cells[idx] = layer(x_t, (h, c))
+          x_t = self.hidden[idx]
+        #x_t = self.nonlinearity(self.network_out(x_t))
+        x_t = self.network_out(x_t)
+        action.append(x_t)
+
+      x = torch.stack([a.float() for a in action])
+
+    else:
+      if dims == 1: # if we get a single timestep (if not, assume we got a batch of single timesteps)
+        x = x.view(1, -1)
+
+      for idx, layer in enumerate(self.actor_layers):
+        h, c = self.hidden[idx], self.cells[idx]
+        self.hidden[idx], self.cells[idx] = layer(x, (h, c))
+        x = self.hidden[idx]
+      #x = self.nonlinearity(self.network_out(x))[0]
+      x = self.network_out(x)
+
+      if dims == 1:
+        x = x.view(-1)
+
+    mu = x
+    if self.learn_std:
+      sd = torch.clamp(self.log_stds(x), -20, 2).exp()
+    else:
+      sd = self.fixed_std
+
+    return mu, sd
+
+  def init_hidden_state(self, batch_size=1):
+    self.hidden = [torch.zeros(batch_size, l.hidden_size) for l in self.actor_layers]
+    self.cells  = [torch.zeros(batch_size, l.hidden_size) for l in self.actor_layers]
+
+  def forward(self, state, deterministic=True):
+    mu, sd = self._get_dist_params(state)
+
+    if not deterministic:
+      self.action = torch.distributions.Normal(mu, sd).sample()
+    else:
+      self.action = mu
+
+    return self.action
+
+  def pdf(self, state):
+    mu, sd = self._get_dist_params(state)
+    return torch.distributions.Normal(mu, sd)
+
   def get_action(self):
     return self.action
 
@@ -299,3 +324,5 @@ def normc_fn(m):
         m.weight.data *= 1 / torch.sqrt(m.weight.data.pow(2).sum(1, keepdim=True))
         if m.bias is not None:
             m.bias.data.fill_(0)
+
+GaussianMLP_Actor = Gaussian_FF_Actor # for legacy code compatibility

--- a/rl/policies/critic.py
+++ b/rl/policies/critic.py
@@ -34,19 +34,18 @@ class Critic(Net):
 
     return (r - self.welford_reward_mean) / torch.sqrt(self.welford_reward_mean_diff / self.welford_reward_n)
 
-class GaussianMLP_Critic(Critic):
-  def __init__(self, state_dim, hidden_size=256, hidden_layers=2, env_name='NOT SET', nonlinearity=torch.tanh, init_std=1, learn_std=True, bounded=False, normc_init=True, obs_std=None, obs_mean=None):
-    super(GaussianMLP_Critic, self).__init__()
+class FF_V(Critic):
+  def __init__(self, state_dim, layers=(256, 256), env_name='NOT SET', normc_init=True, obs_std=None, obs_mean=None):
+    super(FF_V, self).__init__()
 
     self.critic_layers = nn.ModuleList()
-    self.critic_layers += [nn.Linear(state_dim, hidden_size)]
-    for _ in range(hidden_layers-1):
-        self.critic_layers += [nn.Linear(hidden_size, hidden_size)]
-    self.network_out = nn.Linear(hidden_size, 1)
+    self.critic_layers += [nn.Linear(state_dim, layers[0])]
+    for i in range(len(layers)-1):
+        self.critic_layers += [nn.Linear(layers[i], layers[i+1])]
+    self.network_out = nn.Linear(layers[-1], 1)
 
     self.env_name = env_name
-    self.nonlinearity = nonlinearity
-    
+
     self.obs_std = obs_std
     self.obs_mean = obs_mean
 
@@ -72,37 +71,47 @@ class GaussianMLP_Critic(Critic):
 
     return value
 
-  def act(self, inputs):
-    value = self(inputs)
-    return value
+  def act(self, inputs): # not needed, deprecated
+    return self(inputs)
 
 
-class FF_Critic(Critic):
-  def __init__(self, state_dim, action_dim, hidden_size=256, hidden_layers=2, env_name='NOT SET'):
-    super(FF_Critic, self).__init__()
+class FF_Q(Critic):
+  def __init__(self, state_dim, action_dim, layers=(256, 256), env_name='NOT SET', normc_init=True, obs_std=None, obs_mean=None):
+    super(FF_Q, self).__init__()
 
     self.critic_layers = nn.ModuleList()
-    self.critic_layers += [nn.Linear(state_dim + action_dim, hidden_size)]
-    for _ in range(hidden_layers-1):
-        self.critic_layers += [nn.Linear(hidden_size, hidden_size)]
-    self.network_out = nn.Linear(hidden_size, 1)
+    self.critic_layers += [nn.Linear(state_dim + action_dim, layers[0])]
+    for i in range(len(layers)-1):
+        self.critic_layers += [nn.Linear(layers[i], layers[i+1])]
+    self.network_out = nn.Linear(layers[-1], 1)
 
     self.env_name = env_name
-    self.initialize_parameters()
+
+    self.obs_std = obs_std
+    self.obs_mean = obs_mean
+
+    # weight initialization scheme used in PPO paper experiments
+    self.normc_init = normc_init
+    
+    self.init_parameters()
+    self.train()
+
+  def init_parameters(self):
+    if self.normc_init:
+        print("Doing norm column initialization.")
+        self.apply(normc_fn)
 
   def forward(self, state, action):
+    if self.training == False:
+        state = (state - self.obs_mean) / self.obs_std
 
-    if len(state.size()) > 2:
-      x = torch.cat([state, action], 2)
-    elif len(state.size()) > 1:
-      x = torch.cat([state, action], 1)
-    else:
-      x = torch.cat([state, action])
+    x = torch.cat([state, action], len(state.size())-1)
 
-    for idx, layer in enumerate(self.critic_layers):
-      x = F.relu(layer(x))
+    for l in self.critic_layers:
+        x = F.relu(l(x))
+    value = self.network_out(x)
 
-    return self.network_out(x)
+    return value
 
 class Dual_Q_Critic(Critic):
   def __init__(self, state_dim, action_dim, hidden_size=256, hidden_layers=2, env_name='NOT SET'):
@@ -126,14 +135,7 @@ class Dual_Q_Critic(Critic):
 
   def forward(self, state, action):
 
-    # print(state.size(), state)
-    #print(action.size(), action)
-    if len(state.size()) > 2:
-      x1 = torch.cat([state, action], 2)
-    elif len(state.size()) > 1:
-      x1 = torch.cat([state, action], 1)
-    else:
-      x1 = torch.cat([state, action])
+    x1 = torch.cat([state, action], len(state.size())-1)
 
     x2 = x1
 
@@ -163,21 +165,23 @@ class Dual_Q_Critic(Critic):
 
     return self.q1_out(x1)
 
-
-class LSTM_Critic(Critic):
-  def __init__(self, input_dim, action_dim, hidden_size=64, hidden_layers=1, env_name='NOT SET'):
-    super(LSTM_Critic, self).__init__()
+class LSTM_Q(Critic):
+  def __init__(self, input_dim, action_dim, layers=(128, 128), env_name='NOT SET', normc_init=True):
+    super(LSTM_Q, self).__init__()
 
     self.critic_layers = nn.ModuleList()
-    self.critic_layers += [nn.LSTMCell(input_dim + action_dim, hidden_size)]
-    for _ in range(hidden_layers-1):
-        self.critic_layers += [nn.LSTMCell(hidden_size, hidden_size)]
-    self.network_out = nn.Linear(hidden_size, 1)
+    self.critic_layers += [nn.LSTMCell(input_dim + action_dim, layers[0])]
+    for i in range(len(layers)-1):
+        self.critic_layers += [nn.LSTMCell(layers[i], layers[i+1])]
+    self.network_out = nn.Linear(layers[-1], 1)
 
     self.init_hidden_state()
 
     self.is_recurrent = True
     self.env_name = env_name
+
+    if normc_init:
+      self.initialize_parameters()
 
   def get_hidden_state(self):
     return self.hidden, self.cells
@@ -187,15 +191,16 @@ class LSTM_Critic(Critic):
     self.cells  = [torch.zeros(batch_size, l.hidden_size) for l in self.critic_layers]
   
   def forward(self, state, action):
+    dims = len(state.size())
+
     if len(state.size()) != len(action.size()):
       print("state and action must have same number of dimensions: {} vs {}", state.size(), action.size())
       exit(1)
 
-    if len(state.size()) == 3: # if we get a batch of trajectories
+    if dims == 3: # if we get a batch of trajectories
       self.init_hidden_state(batch_size=state.size(1))
       value = []
       for t, (state_batch_t, action_batch_t) in enumerate(zip(state, action)):
-        #print(state_batch_t.size(), action_batch_t.size())
         x_t = torch.cat([state_batch_t, action_batch_t], 1)
 
         for idx, layer in enumerate(self.critic_layers):
@@ -207,38 +212,80 @@ class LSTM_Critic(Critic):
 
       x = torch.stack([a.float() for a in value])
 
-    elif len(state.size()) == 2: # if we get a trajectory
-      self.init_hidden_state()
+    else:
 
+      x = torch.cat([state, action], len(state_t.size()))
+      if dims == 1:
+        x = x.view(1, -1)
+
+      for idx, layer in enumerate(self.critic_layers):
+        c, h = self.cells[idx], self.hidden[idx]
+        self.hidden[idx], self.cells[idx] = layer(x_t, (h, c))
+        x = self.hidden[idx]
+      x = self.network_out(x)
+      
+      if dims == 1:
+        x = x.view(-1)
+
+    return x
+
+class LSTM_V(Critic):
+  def __init__(self, input_dim, layers=(128, 128), env_name='NOT SET', normc_init=True):
+    super(LSTM_V, self).__init__()
+
+    self.critic_layers = nn.ModuleList()
+    self.critic_layers += [nn.LSTMCell(input_dim, layers[0])]
+    for i in range(len(layers)-1):
+        self.critic_layers += [nn.LSTMCell(layers[i], layers[i+1])]
+    self.network_out = nn.Linear(layers[-1], 1)
+
+    self.init_hidden_state()
+
+    self.is_recurrent = True
+    self.env_name = env_name
+
+    if normc_init:
+      self.initialize_parameters()
+
+  def get_hidden_state(self):
+    return self.hidden, self.cells
+
+  def init_hidden_state(self, batch_size=1):
+    self.hidden = [torch.zeros(batch_size, l.hidden_size) for l in self.critic_layers]
+    self.cells  = [torch.zeros(batch_size, l.hidden_size) for l in self.critic_layers]
+  
+  def forward(self, state):
+    dims = len(state.size())
+
+    if dims == 3: # if we get a batch of trajectories
+      self.init_hidden_state(batch_size=state.size(1))
       value = []
-      for t, (state_t, action_t) in enumerate(zip(state, action)):
-        x_t = torch.cat([state_t, action_t])
-        x_t = x_t.view(1, -1)
-
+      for t, state_batch_t in enumerate(state):
+        x_t = state_batch_t
         for idx, layer in enumerate(self.critic_layers):
           c, h = self.cells[idx], self.hidden[idx]
-          #self.cells[idx], self.hidden[idx] = layer(x_t, (c, h))
           self.hidden[idx], self.cells[idx] = layer(x_t, (h, c))
           x_t = self.hidden[idx]
         x_t = self.network_out(x_t)
         value.append(x_t)
 
-      x = torch.cat([a.float() for a in value])
+      x = torch.stack([a.float() for a in value])
 
-    elif len(state.size()) == 1: # if we get a single timestep
-      print("MAKE SURE THIS WORKS.")
-      x = torch.cat([state_t, action_t], 1)
-      x = x.view(1, -1)
+    else:
+      x = state
+      if dims == 1:
+        x = x.view(1, -1)
 
       for idx, layer in enumerate(self.critic_layers):
         c, h = self.cells[idx], self.hidden[idx]
-        #self.cells[idx], self.hidden[idx] = layer(x, (c, h))
-        self.hidden[idx], self.cells[idx] = layer(x_t, (h, c))
+        self.hidden[idx], self.cells[idx] = layer(x, (h, c))
         x = self.hidden[idx]
       x = self.network_out(x)
 
-    else:
-      print("Invalid input dimensions.")
-      exit(1)
+      if dims == 1:
+        x = x.view(-1)
+
     return x
 
+
+GaussianMLP_Critic = FF_V

--- a/rl/policies/critic.py
+++ b/rl/policies/critic.py
@@ -35,7 +35,7 @@ class Critic(Net):
     return (r - self.welford_reward_mean) / torch.sqrt(self.welford_reward_mean_diff / self.welford_reward_n)
 
 class FF_V(Critic):
-  def __init__(self, state_dim, layers=(256, 256), env_name='NOT SET', normc_init=True, obs_std=None, obs_mean=None):
+  def __init__(self, state_dim, layers=(256, 256), env_name='NOT SET', nonlinearity=torch.nn.functional.relu, normc_init=True, obs_std=None, obs_mean=None):
     super(FF_V, self).__init__()
 
     self.critic_layers = nn.ModuleList()
@@ -45,6 +45,8 @@ class FF_V(Critic):
     self.network_out = nn.Linear(layers[-1], 1)
 
     self.env_name = env_name
+
+    self.nonlinearity = nonlinearity
 
     self.obs_std = obs_std
     self.obs_mean = obs_mean


### PR DESCRIPTION
Don't merge this branch quite yet - wanted to get some feedback on some policy refactoring I did. Big changes:

- Changed the num_layers, hidden_size args to a tuple (like in Pedro's old deep-rl code), as I figured we don't really use this as a hyperparameter; I probably shouldn't have changed this in the first place (oops).

- Renamed GaussianMLP_Actor to Gaussian_FF_Actor
- Renamed FF_Critic to FF_Q, and GaussianMLP_Critic to FF_V.
- Merged FF_Actor and Scaled_FF_Actor, as they are functionally identical with the max_action arg
- Added  LSTM_Q and LSTM_V to critic.py 

If any of these changes present a problem, let me know. I'm also open to changing the renaming scheme for GaussianMLP_X.